### PR TITLE
Avoid blank item creation in nfsio_discovery.sh

### DIFF
--- a/nfsio_discovery.sh
+++ b/nfsio_discovery.sh
@@ -15,6 +15,11 @@
 
 array="$(findmnt -lo target -n -t nfs,nfs4)"
 
+if [[ -z "$array" ]]; then
+    printf '%s' '{"data":[]}'
+    exit 0
+fi
+
 comma=""
 printf '%s' '{"data":['
 


### PR DESCRIPTION
Return `{"data":[]}` instead of `{"data":[{"{#MOUNT_POINT}":""}]}` when NFS mount points don't exist.
Close #1.